### PR TITLE
Fix invalid license in META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -4,7 +4,7 @@
     "version" : "0.0.2",
     "description" : "Satoshi Nakamoto's binary-to-text encoding",
     "authors" : [ "Lucien Grondin" ],
-    "license" : "MIT-License",
+    "license" : "MIT",
     "provides" : {
         "Base58" : "lib/Base58.rakumod"
     },


### PR DESCRIPTION
The license field should be a valid SPDX identifier as mentioned under https://docs.raku.org/language/modules#Preparing_the_module

The MIT License SPDX identifier is just `MIT` - https://spdx.org/licenses/MIT.html